### PR TITLE
Add a makefile and rename main.c to waveform.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /bin/waveform
 /build
+
+# Executable built by `make`.
+/waveform

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ generateWaveform(audiofile, pngfile, {
 
 ## Compile:
 
-    gcc -o waveform main.c -O3 -lgroove -lz -lpng
+    make
 
 ## Related Projects
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -12,7 +12,7 @@
         "-lpng"
       ],
       "sources": [
-        "main.c"
+        "waveform.c"
       ],
       "conditions": [
         ['OS=="mac"', {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function(audiofile, pngfile, options, callback) {
           cmdline.push('--' + flagName);
       }
   });
-  
+
   execFile(waveformBin, cmdline, function(err, stdout, stderr) {
     var myErr;
     if (err) {

--- a/makefile
+++ b/makefile
@@ -1,0 +1,4 @@
+CFLAGS = -Wall -O3
+LDLIBS = -lgroove -lz -lpng
+
+waveform:

--- a/waveform.c
+++ b/waveform.c
@@ -61,7 +61,7 @@ static void emit_column() {
     int y = 0;
     int four_x = 4 * x;
 
-    // top bg 
+    // top bg
     for (; y < y_min; ++y) {
         memcpy(row_pointers[y] + four_x, color_bg, 4);
     }


### PR DESCRIPTION
Create a makefile. Add a default compilation rule. This makes it possible to
compile waveform by executing `make`.

Rename `main.c` to `waveform.c`. This allows us to depend upon make's implicit
compilation rules rather than explicitly writing a compilation rule. Adjust
`binding.gyp` accordingly.

Drop some trailing whitespace from `index.js` and `waveform.c`. Make git ignore
`/waveform`, the executable produced by make.
